### PR TITLE
initial support for static imports

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -71,6 +71,6 @@ func runCmd(_ *Command, args []string) {
 		output   = glockfileWriter(importPath, *cmdN)
 	)
 	outputCmds(output, cmds)
-	outputDeps(output, depRoots)
+	outputDeps(output, depRoots, map[string]staticImport{})
 	output.Close()
 }


### PR DESCRIPTION
Add `--glock static` line to the end of your glock file.

When you `glock save` it will use those static dependencies instead of what glock save would have picked up.

Example:

```
--glock static
github.com/manucorporat/sse b7eeebd8987e6b233e43db2551d43f71b2e115d5
github.com/gin-gonic/contrib b2cb99d7b24dd6e33f273f3e0862b6deec2d57e7
github.com/gin-gonic/gin e899d8a99eac4cfeadbeef09017b304d2b918b85
```
